### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Breeze takes a lot of cues from both [MagicalRecord](https://github.com/magicalp
 
 ## Install
 
-Install using Cocoapods
+Install using CocoaPods
 
     pod "Breeze"
 
 Then import <Breeze.h/Breeze.h> into your .pch file
 
-__Right now Swift does not work with Cocoapods, so download the files and include them manually... :-(__
+__Right now Swift does not work with CocoaPods, so download the files and include them manually... :-(__
 
 ## Setup
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
